### PR TITLE
Fixes bug where candidates and jobs for different organisations had duplicate cache key

### DIFF
--- a/clients/assessments/job.go
+++ b/clients/assessments/job.go
@@ -50,7 +50,7 @@ func (client Client) GetJobByVendor(vendor string, vendorId string, token string
 	request.Header.Add("Content-Type", "application/json")
 
 	// Get key
-	key := client.ApiClient.GenerateKey(JOB_TAG_PREFIX + path)
+	key := client.ApiClient.GenerateKey(JOB_TAG_PREFIX + path + token)
 
 	// Perform Request
 	res, err := client.ApiClient.HandleRequest(request, key)

--- a/clients/candidates/candidates.go
+++ b/clients/candidates/candidates.go
@@ -47,7 +47,7 @@ func (client Client) GetCandidateByVendor(vendor string, vendorId string, token 
 	request.Header.Add("Content-Type", "application/json")
 
 	// Get key
-	key := client.ApiClient.GenerateKey(CANDIDATE_TAG_PREFIX + path)
+	key := client.ApiClient.GenerateKey(CANDIDATE_TAG_PREFIX + path + token)
 
 	// Perform Request
 	res, err := client.ApiClient.HandleRequest(request, key)


### PR DESCRIPTION
Fixes bug where candidates and jobs for different organisations resulted in the same cache key and therefore duplicates were reported